### PR TITLE
Downgrade version for compatibility

### DIFF
--- a/src/hyperlane/HyperlaneHelper.sol
+++ b/src/hyperlane/HyperlaneHelper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity >=0.8.0;
 
 import "forge-std/Test.sol";
 import "solady/utils/LibString.sol";

--- a/src/hyperlane/HyperlaneHelper.sol
+++ b/src/hyperlane/HyperlaneHelper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.0;
 
 import "forge-std/Test.sol";
 import "solady/utils/LibString.sol";

--- a/src/layerzero/LayerZeroHelper.sol
+++ b/src/layerzero/LayerZeroHelper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.0;
 
 import "forge-std/Test.sol";
 import "forge-std/console.sol";

--- a/src/layerzero/LayerZeroHelper.sol
+++ b/src/layerzero/LayerZeroHelper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity >=0.8.0;
 
 import "forge-std/Test.sol";
 import "forge-std/console.sol";

--- a/test/Hyperlane.t.sol
+++ b/test/Hyperlane.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity >=0.8.0;
 
 import "forge-std/Test.sol";
 

--- a/test/Hyperlane.t.sol
+++ b/test/Hyperlane.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.0;
 
 import "forge-std/Test.sol";
 

--- a/test/LayerZero.t.sol
+++ b/test/LayerZero.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity >=0.8.0;
 
 import "forge-std/Test.sol";
 

--- a/test/LayerZero.t.sol
+++ b/test/LayerZero.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.0;
 
 import "forge-std/Test.sol";
 

--- a/test/Stargate.t.sol
+++ b/test/Stargate.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity >=0.8.0;
 
 import "forge-std/Test.sol";
 

--- a/test/Stargate.t.sol
+++ b/test/Stargate.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.0;
 
 import "forge-std/Test.sol";
 


### PR DESCRIPTION
Currently helper contracts are written in ^0.8.17 and up. Bumped down to ^0.8.0 to be compatible with any 0.8 project without bringing in a new sol version.