### PR TITLE
fix: Hyperlane estimateGas test fix for latest sdk + Corrected domain reading

### DIFF
--- a/src/hyperlane/HyperlaneHelper.sol
+++ b/src/hyperlane/HyperlaneHelper.sol
@@ -112,7 +112,7 @@ contract HyperlaneHelper is Test {
         assembly {
             _sender := mload(add(message, 0x29))
             _recipient := mload(add(message, 0x4d))
-            _originDomain := and(mload(add(message, 0x2d)), 0xffffffff)
+            _originDomain := and(mload(add(message, 0x09)), 0xffffffff)
         }
         address recipient = TypeCasts.bytes32ToAddress(_recipient);
         uint32 originDomain = uint32(_originDomain);

--- a/utils/scripts/estimateHLGas.ts
+++ b/utils/scripts/estimateHLGas.ts
@@ -7,8 +7,8 @@ import {
 import { ethers } from "ethers";
 
 // Usage: node estimateHLGas.js <origin> <destination> <handleGas>
-const origin = process.argv[2] as ChainName;
-const destination = process.argv[3] as ChainName;
+const origin = process.argv[2] || "ethereum";
+const destination = process.argv[3] || "polygon";
 const handleGas = process.argv[4] || 200000;
 
 const encoder = ethers.utils.defaultAbiCoder;

--- a/utils/scripts/estimateHLGas.ts
+++ b/utils/scripts/estimateHLGas.ts
@@ -1,14 +1,14 @@
 import {
-  chainConnectionConfigs,
-  DomainIdToChainName,
   InterchainGasCalculator,
   MultiProvider,
   ChainName,
+  chainMetadata,
 } from "@hyperlane-xyz/sdk";
 import { ethers } from "ethers";
 
-const origin = DomainIdToChainName[process.argv[2]] || "ethereum";
-const destination = DomainIdToChainName[process.argv[3]] || "polygon";
+// Usage: node estimateHLGas.js <origin> <destination> <handleGas>
+const origin = process.argv[2] as ChainName;
+const destination = process.argv[3] as ChainName;
 const handleGas = process.argv[4] || 200000;
 
 const encoder = ethers.utils.defaultAbiCoder;
@@ -16,14 +16,15 @@ const encoder = ethers.utils.defaultAbiCoder;
 const calculateGas = async () => {
   // Set up a MultiProvider with the default providers.
   const multiProvider = new MultiProvider({
-    arbitrum: chainConnectionConfigs.arbitrum,
-    avalanche: chainConnectionConfigs.avalanche,
-    bsc: chainConnectionConfigs.bsc,
-    celo: chainConnectionConfigs.celo,
-    ethereum: chainConnectionConfigs.ethereum,
-    optimism: chainConnectionConfigs.optimism,
-    polygon: chainConnectionConfigs.polygon,
-    moonbeam: chainConnectionConfigs.moonbeam,
+    arbitrum: chainMetadata.arbitrum,
+    avalanche: chainMetadata.avalanche,
+    bsc: chainMetadata.bsc,
+    celo: chainMetadata.celo,
+    ethereum: chainMetadata.ethereum,
+    optimism: chainMetadata.optimism,
+    polygon: chainMetadata.polygon,
+    moonbeam: chainMetadata.moonbeam,
+    gnosis: chainMetadata.gnosis,
   });
 
   // Create the calculator.

--- a/utils/scripts/package.json
+++ b/utils/scripts/package.json
@@ -10,6 +10,6 @@
   },
   "scripts": {
     "compile": "npx tsc ./*.ts",
-    "estimateHLGas": "node estimateHLGas.js ethereum polygon"
+    "estimateHLGas": "node estimateHLGas.js"
   }
 }

--- a/utils/scripts/package.json
+++ b/utils/scripts/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@hyperlane-xyz/sdk": "^1.0.0",
+    "@hyperlane-xyz/sdk": "^1.2.3",
     "ethers": "^5.7.2",
     "fs": "^0.0.1-security"
   },
@@ -10,6 +10,6 @@
   },
   "scripts": {
     "compile": "npx tsc ./*.ts",
-    "estimateHLGas": "node estimateHLGas.js"
+    "estimateHLGas": "node estimateHLGas.js ethereum polygon"
   }
 }


### PR DESCRIPTION
- Currently latest hyperlane sdk doesnt export some of the methods like chainConnectionConfigs, DomainIdToChainName that are used in gasEstimation, updated those methods with the latest methods that work for the gas estimate
- originDomain of HyperLane helper must read from hex 0x09 instead of 0x2d  - current hyperlaneHelper is reading destinationDomain which is wrong
  
